### PR TITLE
Fix `buildall.sh` to support multi-user cloud builds...

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 # This script generates code for all modules and merges the content files.
+
+mkdir -p libs/modules/content
+
 python3 tools/sqs/sqs.py generate world.module.json
 python3 tools/sqs/sqs.py generate room-squidhall.module.json
 python3 tools/sqs/sqs.py generate room-wheketere.module.json


### PR DESCRIPTION
`buildall.sh` does not contain any _bashisms_ and will run just fine
as a posix shell script. Our cloud runtime environment is based on
Alpine Linux and currently does not have `bash` installed.

`sqs.py generate` expects certain output folders exist.
`buildall.sh` easily can ensure this with `mkdir -p`.